### PR TITLE
Correção na formatação do artigo

### DIFF
--- a/content/posts/tudo-que-voce-queria-saber-sobre-git-e-github-mas-tinha-vergonha-de-perguntar.md
+++ b/content/posts/tudo-que-voce-queria-saber-sobre-git-e-github-mas-tinha-vergonha-de-perguntar.md
@@ -85,199 +85,200 @@ Com o repositório na sua máquina, vamos aprender 4 comandos iniciais que farã
   * `git status` Exibe o status do seu repositório atual </ul> 
     ## Vamos praticar!
     
-    Chegou o momento de praticar um pouco o que vimos até agora, e com bastante calma para que você possa entender cada passo. Após clonar o seu projeto, crie o arquivo `index.html` na pasta site que é o seu repositório git. Após criar o arquivo, execute o comando `git status`. A resposta é semelhante a figura a seguir:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_touch_index.png" alt="git_touch_index" width="628" height="284" class="alignleft size-full wp-image-51179" />
-    
-    Ou seja, o comando `git status` nos trouxe várias informações, que iremos ignorar a princípio, exceto pelo `Untracked files`, dizendo que existe um arquivo que não está sendo &#8220;mapeado&#8221; pelo git. Para preparar este arquivo para o seu versionamento, usamos o comando `git add`, veja:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_add.png" alt="git_add" width="600" height="272" class="alignleft size-full wp-image-51180" />
-    
-    Agora temos o nosso arquivo index.html no INDEX do repositório, ou se você quiser pensar: &#8220;preparado para um commit&#8221;. Para commitar este arquivo, usamos:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_commit.png" alt="git_commit" width="760" height="248" class="alignleft size-full wp-image-51182" />
-    
-    Após &#8220;commitar&#8221; o arquivo, ele já está presente no nosso repositório local, tanto que realizamos o comando `git status` novamente e ele retornou que não havia nada de novo no projeto. Perceba agora que, mesmo recarregando o projeto no github, nada muda. Ou seja, estas mudanças até agora foram locais, você pode realizar várias operações antes de publicá-las no github. Para publicar, usamos o comando `git push`:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_push.png" alt="git_push" width="600" height="255" class="alignleft size-full wp-image-51184" />
-    
-    Após realizar o git push podemos ver no site github as mudanças realizadas no projeto:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/github_site2.png" alt="github_site2" width="812" height="552" class="alignleft size-full wp-image-51185" />
-    
-    Desta forma, aprendemos os 4 comandos mais básicos do git, e com ele podemos começar a compreender como funciona o processo de versionamento de arquivos com git e github.
-    
-    ### Errei a mensagem do commit, como arrumo?
-    
-    Imagine que você tenha errado a mensagem que escreveu no commit ou simplesmente queira melhorar a descrição do seu trabalho. Você já comitou a mensagem mas ainda não fez o push das suas modificações para o servidor. Nesse caso você usa a flag `--amend`. Fica assim:
-    
-    <pre class="lang-shell">$ git commit --amend</pre>
-    
-    O `git commit --amend` modifica a mensagem do commit mais recente, ou seja, o último commit feito por você no projeto. Além de você mudar a mensagem do commit, você consegue adicionar arquivos que você se esqueceu ou retirar arquivos comitados por engano. O git cria um commit totalmente novo e corrigido.
-    
-    ## Cadê o git pull?
-    
-    Ainda existe um comando importante neste processo, que é o `git pull`. Ele é usado para trazer todas as modificações que estão no github para o seu projeto local. Isso é vital quando existem projetos mantidos por mais de uma pessoa, ou se você possui duas máquinas e precisa manter a sincronia entre elas. Supondo que você possui uma máquina no trabalho e outra em casa. Ambas tem o repositório local ligado ao github. Quando você executar um `git push` em uma das máquinas, terá que realizar um `git pull` na outra.
-    
-    Para exemplificar, vamos alterar o arquivo README.md diretamente no github. Isso é possível clicando no arquivo e depois clicando no ícone para edição, conforme a imagem a seguir.
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/github_edit.png" alt="github_edit" width="935" height="356" class="alignleft size-full wp-image-51241" />
-    
-    Após clicar em edit, adicione algum texto, forneça uma mensagem de commit e clique no botão &#8220;Commit Changes&#8221;. Com isso, uma nova revisão no seu projeto é criada, mas como ela foi gerada no github, o seu projeto local está desatualizado. Para atualizar o seu projeto, use `git pull`, e perceba que o arquivo README.md é atualizado de acordo com a sua última revisão, semelhante a figura a seguir.
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git-pull.png" alt="git-pull" width="520" height="285" class="alignleft size-full wp-image-51242" />
-    
-    ## Melhorando o conceito do comando git add
-    
-    Possivelmente você imaginou que o comando `git add` é usado para novos arquivos, mas isso não é verdade. O comando `add` é usado para adicionar qualquer alteração de arquivo ao INDEX do git, que é uma área especial onde os arquivos estão sendo preparados para o commit. Quando usamos `add`, estamos dizendo que o arquivo estará adicionando ao próximo commit, quando este for realizado. Isso é necessário porque nem sempre queremos que todos os arquivos que alteramos sejam comitados.
-    
-    Vamos a um exemplo simples, adicionando o seguinte código no arquivo index.html:
-    
-    <pre class="lang-html">&lt;!DOCTYPE html&gt;
+Chegou o momento de praticar um pouco o que vimos até agora, e com bastante calma para que você possa entender cada passo. Após clonar o seu projeto, crie o arquivo `index.html` na pasta site que é o seu repositório git. Após criar o arquivo, execute o comando `git status`. A resposta é semelhante a figura a seguir:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_touch_index.png" alt="git_touch_index" width="628" height="284" class="alignleft size-full wp-image-51179" />
+
+Ou seja, o comando `git status` nos trouxe várias informações, que iremos ignorar a princípio, exceto pelo `Untracked files`, dizendo que existe um arquivo que não está sendo &#8220;mapeado&#8221; pelo git. Para preparar este arquivo para o seu versionamento, usamos o comando `git add`, veja:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_add.png" alt="git_add" width="600" height="272" class="alignleft size-full wp-image-51180" />
+
+Agora temos o nosso arquivo index.html no INDEX do repositório, ou se você quiser pensar: &#8220;preparado para um commit&#8221;. Para commitar este arquivo, usamos:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_commit.png" alt="git_commit" width="760" height="248" class="alignleft size-full wp-image-51182" />
+
+Após &#8220;commitar&#8221; o arquivo, ele já está presente no nosso repositório local, tanto que realizamos o comando `git status` novamente e ele retornou que não havia nada de novo no projeto. Perceba agora que, mesmo recarregando o projeto no github, nada muda. Ou seja, estas mudanças até agora foram locais, você pode realizar várias operações antes de publicá-las no github. Para publicar, usamos o comando `git push`:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_push.png" alt="git_push" width="600" height="255" class="alignleft size-full wp-image-51184" />
+
+Após realizar o git push podemos ver no site github as mudanças realizadas no projeto:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/github_site2.png" alt="github_site2" width="812" height="552" class="alignleft size-full wp-image-51185" />
+
+Desta forma, aprendemos os 4 comandos mais básicos do git, e com ele podemos começar a compreender como funciona o processo de versionamento de arquivos com git e github.
+
+### Errei a mensagem do commit, como arrumo?
+
+Imagine que você tenha errado a mensagem que escreveu no commit ou simplesmente queira melhorar a descrição do seu trabalho. Você já comitou a mensagem mas ainda não fez o push das suas modificações para o servidor. Nesse caso você usa a flag `--amend`. Fica assim:
+
+<pre class="lang-shell">$ git commit --amend</pre>
+
+O `git commit --amend` modifica a mensagem do commit mais recente, ou seja, o último commit feito por você no projeto. Além de você mudar a mensagem do commit, você consegue adicionar arquivos que você se esqueceu ou retirar arquivos comitados por engano. O git cria um commit totalmente novo e corrigido.
+
+## Cadê o git pull?
+
+Ainda existe um comando importante neste processo, que é o `git pull`. Ele é usado para trazer todas as modificações que estão no github para o seu projeto local. Isso é vital quando existem projetos mantidos por mais de uma pessoa, ou se você possui duas máquinas e precisa manter a sincronia entre elas. Supondo que você possui uma máquina no trabalho e outra em casa. Ambas tem o repositório local ligado ao github. Quando você executar um `git push` em uma das máquinas, terá que realizar um `git pull` na outra.
+
+Para exemplificar, vamos alterar o arquivo README.md diretamente no github. Isso é possível clicando no arquivo e depois clicando no ícone para edição, conforme a imagem a seguir.
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/github_edit.png" alt="github_edit" width="935" height="356" class="alignleft size-full wp-image-51241" />
+
+Após clicar em edit, adicione algum texto, forneça uma mensagem de commit e clique no botão &#8220;Commit Changes&#8221;. Com isso, uma nova revisão no seu projeto é criada, mas como ela foi gerada no github, o seu projeto local está desatualizado. Para atualizar o seu projeto, use `git pull`, e perceba que o arquivo README.md é atualizado de acordo com a sua última revisão, semelhante a figura a seguir.
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git-pull.png" alt="git-pull" width="520" height="285" class="alignleft size-full wp-image-51242" />
+
+## Melhorando o conceito do comando git add
+
+Possivelmente você imaginou que o comando `git add` é usado para novos arquivos, mas isso não é verdade. O comando `add` é usado para adicionar qualquer alteração de arquivo ao INDEX do git, que é uma área especial onde os arquivos estão sendo preparados para o commit. Quando usamos `add`, estamos dizendo que o arquivo estará adicionando ao próximo commit, quando este for realizado. Isso é necessário porque nem sempre queremos que todos os arquivos que alteramos sejam comitados.
+
+Vamos a um exemplo simples, adicionando o seguinte código no arquivo index.html:
+
+<pre class="lang-html">
+&lt;!DOCTYPE html&gt;
 &lt;html&gt;
 &lt;head&gt;
 &lt;meta charset="UTF-8"&gt;
-    &lt;title&gt; Meu Site &lt;/title&gt;
+&lt;title&gt; Meu Site &lt;/title&gt;
 &lt;/head&gt;
 &lt;body&gt;
 &lt;/body&gt;
 &lt;/html&gt;
 </pre>
-    
-    Após salvar este modelo html, o comando git status irá apresentar:
-    
-    <pre>modified:   index.html
+
+Após salvar este modelo html, o comando git status irá apresentar:
+
+<pre>modified:   index.html
 </pre>
-    
-    Para adicionar o arquivo e prepará-lo para o commit, usamos `git add index.html`. Desta forma, ele está pronto para usarmos o comando `git commit`, o que não faremos agora. Antes disso, altere novamente o arquivo e adicione algum texto entre as tags body, por exemplo:
-    
-    <pre class="lang-html">&lt;!DOCTYPE html&gt;
+
+Para adicionar o arquivo e prepará-lo para o commit, usamos `git add index.html`. Desta forma, ele está pronto para usarmos o comando `git commit`, o que não faremos agora. Antes disso, altere novamente o arquivo e adicione algum texto entre as tags body, por exemplo:
+
+<pre class="lang-html">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
 &lt;head&gt;
 &lt;meta charset="UTF-8"&gt;
-    &lt;title&gt; Meu Site &lt;/title&gt;
+&lt;title&gt; Meu Site &lt;/title&gt;
 &lt;/head&gt;
 &lt;body&gt;
- Esse é meu site
+Esse é meu site
 &lt;/body&gt;
 &lt;/html&gt;
 </pre>
-    
-    Após alterar o arquivo, temos a seguinte situação:
-    
-      1. Adicionamos o conteúdo html no arquivo index.html
-      2. Realizamos `git add index.html`
-      3. Alteramos index.html e adicionamos o texto entre as tags body
-    
-    Neste momento, faça: `git commit -m "Alteração no arquivo index.html"`, e após isso, faça: `git push`. Analise agora no github se a sua alteração na tag body está visível. Ela não estará. Mas porque isso aconteceu? Quando usamos o comando `git add`, aquela alteração no body ainda não tinha sido escrita, então ela não estará pronta até que você faça novamente o comando `git add`. Em termos técnicos, a segunda alteração que fez ainda não está na INDEX do repositório. Como tarefa, faça novamente `git add index.html`, `git commit` e `git push`
-    
-    ## Trabalhando com branches
-    
-    Branches e mergers sempre foram os pesadelos de qualquer gerenciador de versão (ok, do svn&#8230;). No git, o conceito de branch tornou-se algo muito simples e fácil de usar. Mas quando que temos que criar um branch? Imagine que o seu site está pronto, tudo funcionando perfeitamente, mas surge a necessidade de alterar algumas partes dele como forma de melhorá-lo. Além disso, você precisa manter estas alterações tanto no computador de casa quanto do trabalho. Com isso temos um problema, se você começa a alterar os arquivos em casa, para na metade da implementação, e precisa terminar no trabalho, como você iria comitar tudo pela metade e deixar o site incompleto?
-    
-    Para isso existe o conceito de branch, que é justamente ramificar o seu projeto em 2, como se cada um deles fosse um repositório, e depois juntá-lo novamente. Voltando ao github, perceba o detalhe da imagem a seguir.
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/master.png" alt="master" width="821" height="344" class="alignleft size-full wp-image-51249" />
-    
-    Sem saber, você já está em um branch, que chamamos de master. Perceba também que, sempre que usávamos `git status`, o nome do branch é exibido, e sempre que comitávamos ou fazíamos o push, o mesmo aparecia. Ou seja, até este momento fizemos todas as alterações no master. Você pode criar um branch no github ou em linha de comando. Inicialmente, vamos pelo github, criando o branch &#8220;new_menu&#8221;.
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/new_branch.png" alt="new_branch" width="468" height="328" class="alignleft size-full wp-image-51250" />
-    
-    Criamos o branch new_menu, e para que possamos trabalhar nele, usamos o comando `git checkout new_menu`. No primeiro momento que você cria este branch no github, é necessário realizar o comando `git pull` no seu projeto para que ele possa saber que este branch foi criado. Após realizar `git pull`, pode-se alterar para o novo branch, conforme a imagem a seguir.
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/new_menu.png" alt="new_menu" width="604" height="299" class="alignleft size-full wp-image-51252" />
-    
-    Neste momento, estamos no branch `new_menu`, e tudo que fizermos agora será pertencente a ele. Caso haja necessidade de voltar ao branch master, basta realizar o comando `git checkout master`.
-    
-    > Atenção, o comando `checkout` do git não é o mesmo do checkout do svn, caso você o conheça. Ambos tem sentidos totalmente diferentes. 
-    
-    Então, entando no branch new_menu, vamos adicionar um simples menu na página:
-    
-    <pre class="lang-html">&lt;!DOCTYPE html&gt;
+
+Após alterar o arquivo, temos a seguinte situação:
+
+    1. Adicionamos o conteúdo html no arquivo index.html
+    2. Realizamos `git add index.html`
+    3. Alteramos index.html e adicionamos o texto entre as tags body
+
+Neste momento, faça: `git commit -m "Alteração no arquivo index.html"`, e após isso, faça: `git push`. Analise agora no github se a sua alteração na tag body está visível. Ela não estará. Mas porque isso aconteceu? Quando usamos o comando `git add`, aquela alteração no body ainda não tinha sido escrita, então ela não estará pronta até que você faça novamente o comando `git add`. Em termos técnicos, a segunda alteração que fez ainda não está na INDEX do repositório. Como tarefa, faça novamente `git add index.html`, `git commit` e `git push`
+
+## Trabalhando com branches
+
+Branches e mergers sempre foram os pesadelos de qualquer gerenciador de versão (ok, do svn&#8230;). No git, o conceito de branch tornou-se algo muito simples e fácil de usar. Mas quando que temos que criar um branch? Imagine que o seu site está pronto, tudo funcionando perfeitamente, mas surge a necessidade de alterar algumas partes dele como forma de melhorá-lo. Além disso, você precisa manter estas alterações tanto no computador de casa quanto do trabalho. Com isso temos um problema, se você começa a alterar os arquivos em casa, para na metade da implementação, e precisa terminar no trabalho, como você iria comitar tudo pela metade e deixar o site incompleto?
+
+Para isso existe o conceito de branch, que é justamente ramificar o seu projeto em 2, como se cada um deles fosse um repositório, e depois juntá-lo novamente. Voltando ao github, perceba o detalhe da imagem a seguir.
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/master.png" alt="master" width="821" height="344" class="alignleft size-full wp-image-51249" />
+
+Sem saber, você já está em um branch, que chamamos de master. Perceba também que, sempre que usávamos `git status`, o nome do branch é exibido, e sempre que comitávamos ou fazíamos o push, o mesmo aparecia. Ou seja, até este momento fizemos todas as alterações no master. Você pode criar um branch no github ou em linha de comando. Inicialmente, vamos pelo github, criando o branch &#8220;new_menu&#8221;.
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/new_branch.png" alt="new_branch" width="468" height="328" class="alignleft size-full wp-image-51250" />
+
+Criamos o branch new_menu, e para que possamos trabalhar nele, usamos o comando `git checkout new_menu`. No primeiro momento que você cria este branch no github, é necessário realizar o comando `git pull` no seu projeto para que ele possa saber que este branch foi criado. Após realizar `git pull`, pode-se alterar para o novo branch, conforme a imagem a seguir.
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/new_menu.png" alt="new_menu" width="604" height="299" class="alignleft size-full wp-image-51252" />
+
+Neste momento, estamos no branch `new_menu`, e tudo que fizermos agora será pertencente a ele. Caso haja necessidade de voltar ao branch master, basta realizar o comando `git checkout master`.
+
+> Atenção, o comando `checkout` do git não é o mesmo do checkout do svn, caso você o conheça. Ambos tem sentidos totalmente diferentes. 
+
+Então, entando no branch new_menu, vamos adicionar um simples menu na página:
+
+<pre class="lang-html">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
 &lt;head&gt;
 &lt;meta charset="UTF-8"&gt;
-    &lt;title&gt; Meu Site &lt;/title&gt;
+&lt;title&gt; Meu Site &lt;/title&gt;
 &lt;/head&gt;
 
 &lt;body&gt;
-    Meu Site
-    
-    &lt;ul&gt;
-        &lt;li&gt;&lt;a href="index.html"&gt;Home&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a href="sobre.html"&gt;Sobre&lt;/a&gt;&lt;/li&gt;
-        &lt;li&gt;&lt;a href="contato.html"&gt;Contato&lt;/a&gt;&lt;/li&gt;
-    &lt;/ul&gt;
-    
+Meu Site
+
+&lt;ul&gt;
+    &lt;li&gt;&lt;a href="index.html"&gt;Home&lt;/a&gt;&lt;/li&gt;
+    &lt;li&gt;&lt;a href="sobre.html"&gt;Sobre&lt;/a&gt;&lt;/li&gt;
+    &lt;li&gt;&lt;a href="contato.html"&gt;Contato&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;
+
 &lt;/body&gt;
 &lt;/html&gt;
 </pre>
-    
-    Após criar o menu, certifique-se de estar no branch new_menu e faça o commit, conforme a figura a seguir.
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/new_menu_commit.png" alt="new_menu_commit" width="716" height="536" class="alignleft size-full wp-image-51254" />
-    
-    Agora temos algumas modificações no branch new\_menu, e podemos trabalhar nesse branch por quanto tempo for necessário, já que o master está intacto. Aqui temos uma funcionalidade interessante, que se destaca em relação as outras ferramentas de versionamento. Suponha que, no meio do seu desenvolvimento do menu, surge a necessidade de resolver um bug crítico no master, algo como &#8220;está faltando o h1 no título do seu site&#8221;&#8230;. Ou seja, estamos no branch new\_menu e precisamos alterar o master. Para isso, use o comando `git checkout master`. Ao fazer isso, retornamos ao master e aquele menu que criamos não está mais presente, conforme a figura a seguir.
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/back_to_master.png" alt="back_to_master" width="624" height="686" class="alignleft size-full wp-image-51255" />
-    
-    É claro que não perdemos o menu, ele está apenas no branch new_menu. Quando retornarmos a ele, voltará. Agora altere o título do site, incluindo o h1, veja:
-    
-    <pre class="lang-html">&lt;!DOCTYPE html&gt;
+
+Após criar o menu, certifique-se de estar no branch new_menu e faça o commit, conforme a figura a seguir.
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/new_menu_commit.png" alt="new_menu_commit" width="716" height="536" class="alignleft size-full wp-image-51254" />
+
+Agora temos algumas modificações no branch new\_menu, e podemos trabalhar nesse branch por quanto tempo for necessário, já que o master está intacto. Aqui temos uma funcionalidade interessante, que se destaca em relação as outras ferramentas de versionamento. Suponha que, no meio do seu desenvolvimento do menu, surge a necessidade de resolver um bug crítico no master, algo como &#8220;está faltando o h1 no título do seu site&#8221;&#8230;. Ou seja, estamos no branch new\_menu e precisamos alterar o master. Para isso, use o comando `git checkout master`. Ao fazer isso, retornamos ao master e aquele menu que criamos não está mais presente, conforme a figura a seguir.
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/back_to_master.png" alt="back_to_master" width="624" height="686" class="alignleft size-full wp-image-51255" />
+
+É claro que não perdemos o menu, ele está apenas no branch new_menu. Quando retornarmos a ele, voltará. Agora altere o título do site, incluindo o h1, veja:
+
+<pre class="lang-html">&lt;!DOCTYPE html&gt;
 &lt;html&gt;
 &lt;head&gt;
 &lt;meta charset="UTF-8"&gt;
-    &lt;title&gt; Meu Site &lt;/title&gt;
+&lt;title&gt; Meu Site &lt;/title&gt;
 &lt;/head&gt;
 
 &lt;body&gt;
-    &lt;h1&gt;Meu Site&lt;/h1&gt;
+&lt;h1&gt;Meu Site&lt;/h1&gt;
 &lt;/body&gt;
 
 &lt;/html&gt;</pre>
-    
-    Após alterar, faça commit e o push! Veja:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_push2.png" alt="git_push2" width="687" height="529" class="alignleft size-full wp-image-51256" />
-    
-    Agora que resolvemos o problema do título, podemos voltar ao new_menu: `git checkout new_menu`. Após realizar este comando, temos o menu de volta no arquivo index.html, mas veja que o título não possui a tag H1. Isso acontece que estamos em outro branch. Tudo que acontece no master, fica no master. Tudo que acontece no new\_menu, fica no new\_menu
-    
-    ## Merge com conflitos
-    
-    Se desejar trazer o título do master para o new_menu, devemos fazer uma operação chamada `merge`, que irá juntar um código no outro. Então, estando no branch new_menu, e querendo trazer uma alteração do master para este branch, precisamos realizar o seguinte comando: `git merge master`. Caso existam alterações nas mesmas linhas entre mesmos arquivos, um conflito será gerado, como no exemplo a seguir:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/conflict.png" alt="conflict" width="595" height="616" class="alignleft size-full wp-image-51259" />
-    
-    Este é um exemplo de conflito que podo ocorrer quando realizamos um merge, indicado em `1`. Perceba que o código html possui uma definição entre dois blocos, o primeiro, em `2` mostra como é o código do branch new_menu, e o segundo bloco, em `3`, mostra como é o código no branch master. Edite o arquivo repassando para a seguinte forma:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/merge2.png" alt="merge2" width="578" height="613" class="alignleft size-full wp-image-51260" />
-    
-    Ou seja, ajustamos os dois blocos, como se fosse um merge manual. Após resolver o conflito, vamos prepará-lo para o commit no branch new_menu, com o comando `git add`. Veja:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/merge3.png" alt="merge3" width="779" height="105" class="alignleft size-full wp-image-51261" />
-    
-    Ou seja, resolvemos o conflito &#8220;na mão&#8221; e depois comitamos normalmente.
-    
-    ## Merge sem conflitos
-    
-    Quando não alteremos a mesma linha de um arquivo em branches diferentes, conseguimos realizar um merge sem ocasionar conflitos. Isso pode ser notado ao trazermos o menu do branch new_menu para o master, da seguinte forma:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/merge4.png" alt="merge4" width="585" height="652" class="alignleft size-full wp-image-51262" />
-    
-    Se não houver conflitos, basta realizar um commit normal para confirmar o merge.
-    
-    ## Vendo branches e merges
-    
-    O github possui uma ferramenta gráfica para exibir os branches e merges do seu projeto. Clique no ícone em forma de gráfico no menu à direita do site e clique na aba Network, para se ter um resultado semelhante a figura a seguir:
-    
-    <img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/graph.png" alt="graph" width="1027" height="446" class="alignleft size-full wp-image-51265" />
-    
-    ## Lendo mais
-    
-    Você pode ler mais sobre git e entender mais sobre controles de versão, nesses artigos do Tableless:
-    
-      * <a href="http://tableless.com.br/alguns-comandos-git/" target="_blank">Comandos Iniciais do Git</a> 
-      * <a href="http://tableless.com.br/slides-devs-10-git/" target="_blank">Apresentações sobre GIT</a> 
-      * <a href="http://tableless.com.br/iniciando-no-git-parte-1/" target="_blank">Iniciando com GIT &#8211; Parte 1</a> 
-      * <a href="http://tableless.com.br/iniciando-no-git-parte-2/" target="_blank">Iniciando com GIT &#8211; Parte 2</a> 
-      * <a href="http://tableless.com.br/git-com-interface-grafica/" target="_blank">Git com Interface Gráfica</a>
+
+Após alterar, faça commit e o push! Veja:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/git_push2.png" alt="git_push2" width="687" height="529" class="alignleft size-full wp-image-51256" />
+
+Agora que resolvemos o problema do título, podemos voltar ao new_menu: `git checkout new_menu`. Após realizar este comando, temos o menu de volta no arquivo index.html, mas veja que o título não possui a tag H1. Isso acontece que estamos em outro branch. Tudo que acontece no master, fica no master. Tudo que acontece no new\_menu, fica no new\_menu
+
+## Merge com conflitos
+
+Se desejar trazer o título do master para o new_menu, devemos fazer uma operação chamada `merge`, que irá juntar um código no outro. Então, estando no branch new_menu, e querendo trazer uma alteração do master para este branch, precisamos realizar o seguinte comando: `git merge master`. Caso existam alterações nas mesmas linhas entre mesmos arquivos, um conflito será gerado, como no exemplo a seguir:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/conflict.png" alt="conflict" width="595" height="616" class="alignleft size-full wp-image-51259" />
+
+Este é um exemplo de conflito que podo ocorrer quando realizamos um merge, indicado em `1`. Perceba que o código html possui uma definição entre dois blocos, o primeiro, em `2` mostra como é o código do branch new_menu, e o segundo bloco, em `3`, mostra como é o código no branch master. Edite o arquivo repassando para a seguinte forma:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/merge2.png" alt="merge2" width="578" height="613" class="alignleft size-full wp-image-51260" />
+
+Ou seja, ajustamos os dois blocos, como se fosse um merge manual. Após resolver o conflito, vamos prepará-lo para o commit no branch new_menu, com o comando `git add`. Veja:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/merge3.png" alt="merge3" width="779" height="105" class="alignleft size-full wp-image-51261" />
+
+Ou seja, resolvemos o conflito &#8220;na mão&#8221; e depois comitamos normalmente.
+
+## Merge sem conflitos
+
+Quando não alteremos a mesma linha de um arquivo em branches diferentes, conseguimos realizar um merge sem ocasionar conflitos. Isso pode ser notado ao trazermos o menu do branch new_menu para o master, da seguinte forma:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/merge4.png" alt="merge4" width="585" height="652" class="alignleft size-full wp-image-51262" />
+
+Se não houver conflitos, basta realizar um commit normal para confirmar o merge.
+
+## Vendo branches e merges
+
+O github possui uma ferramenta gráfica para exibir os branches e merges do seu projeto. Clique no ícone em forma de gráfico no menu à direita do site e clique na aba Network, para se ter um resultado semelhante a figura a seguir:
+
+<img src="https://raw.githubusercontent.com/diegoeis/tableless-static-images/master/2015/09/graph.png" alt="graph" width="1027" height="446" class="alignleft size-full wp-image-51265" />
+
+## Lendo mais
+
+Você pode ler mais sobre git e entender mais sobre controles de versão, nesses artigos do Tableless:
+
+* <a href="http://tableless.com.br/alguns-comandos-git/" target="_blank">Comandos Iniciais do Git</a> 
+* <a href="http://tableless.com.br/slides-devs-10-git/" target="_blank">Apresentações sobre GIT</a> 
+* <a href="http://tableless.com.br/iniciando-no-git-parte-1/" target="_blank">Iniciando com GIT &#8211; Parte 1</a> 
+* <a href="http://tableless.com.br/iniciando-no-git-parte-2/" target="_blank">Iniciando com GIT &#8211; Parte 2</a> 
+* <a href="http://tableless.com.br/git-com-interface-grafica/" target="_blank">Git com Interface Gráfica</a>


### PR DESCRIPTION
Os códigos são precedidos pelo <pre>, mas havia um <pre> com tab antes, e o motor do markdow estava formatando ele também, o que nao é correto. 